### PR TITLE
Improved link colors in inverted mode

### DIFF
--- a/css/invertColors.css
+++ b/css/invertColors.css
@@ -9,6 +9,15 @@ body, #centeredContent{
     background-color: rgb(0, 0, 0);
 }
 
+/* Better link colors */
+a {
+    color: lightblue;
+}
+
+a:visited {
+    color: cadetblue;
+}
+
 /* asciiRealButton class, used for buttons inside ascii art with borders and stuff */
 
 .asciiRealButton{


### PR DESCRIPTION
Changing default web white do black and default font color doesn't change link colors. That way, inverted mode has unreadable links.

With a few CSS lines I changed the links to lighter blues. Now anyone using inverted mode can see links with improved readability.